### PR TITLE
Use bash instead of sh

### DIFF
--- a/buply
+++ b/buply
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # buply  -  Make using bup a bit easier. 
 


### PR DESCRIPTION
buply uses some bash features and fails with Ubuntu's "sh".  Explicitly
use bash so we are sure we can use bash features.

Here's the error when running buply on a ubunut box:

```
/buply-demo
./buply: 34: ./buply: [[: not found
./buply: 20: ./buply: [[: not found
```
