### PR TITLE
Add parity information generation

### DIFF
--- a/buply
+++ b/buply
@@ -77,10 +77,18 @@ EOF
 DoBupFsck() {
     local bup_dir=$1
     local right_now=$(date +%s)
+    local bup_fsck_options=""
+    if [[ `which par2 >/dev/null` ]]; then
+	if [["$generate_parity_data" == "true" ]]; then
+	    $bup_fsck_options="$bup_fsck_options -g"
+	fi
+	else
+	    echo "!!!!!!par2 command not found"
+    fi
 
     # Run the fsck
-    ${_E} bup fsck \
-	|| ErrorFail "${bup_dir}" "bup fsck" "$?"
+    ${_E} bup fsck $bup_fsck_options \
+	|| ErrorFail "${bup_dir}" "bup fsck $bup_fsck_options" "$?"
 
     # Update the git-config setting to say that the last fsck was run...now
     GIT_DIR=${bup_dir} ${_E} git config buply.${backup_name}.fsckdate ${right_now}

--- a/buply-demo
+++ b/buply-demo
@@ -29,6 +29,9 @@ period="month"
 fsck_period="1 day"
 fsck_period="never"
 
+# Should parity information be generated (using par2)
+generate_parity_data=true
+
 ### You can fancy things with fsck_period too...
 ### For example:
 ###   on-home-network \


### PR DESCRIPTION
This commit adds a configuration parameter to generate parity information using par2.

This could (and I think should) be run after the backup, too.  I'd like to hear your opinion on this first, though.
